### PR TITLE
fix: broken repo URL

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Meatballs - recipes from CG Team
-repo_url: https://github.com/clinicalgenomics/meatballs/
+repo_url: https://github.com/clinical-genomics/meatballs/
 site_author: Clinical Genomics bioinfo team
 dev_addr: 0.0.0.0:8080
 


### PR DESCRIPTION
### This PR fixes:

Fixes broken repository url. 

**How to prepare for test**:
- [ ] `ssh` to ...
- [ ] Install on stage:
`bash servers/resources/SERVER.scilifelab.se/update-[THIS_TOOL]-stage.sh [THIS-BRANCH-NAME]`

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
