### PR TITLE
Removal of redundant porridge in mkdocs.yml 

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,7 +39,6 @@ nav:
   - Breakfast:
       - Porridge: "breakfast/porridge.md" 
       - Boiled Eggs: "breakfast/boiled_egg.md"   
-      - Porridge: "breakfast/porridge.md"
       - American pancakes: "breakfast/pancakes.md"
   - Desserts:
       - Desserts: "Desserts/fruit_sallad.md"


### PR DESCRIPTION
### This PR adds | fixes:
- Remove one of the porridge recipes (they were identical), see https://github.com/Clinical-Genomics/meatballs/issues/42

**How to prepare for test**:
- [ ] `ssh` to ...
- [ ] Install on stage:
`bash servers/resources/SERVER.scilifelab.se/update-[THIS_TOOL]-stage.sh [THIS-BRANCH-NAME]`

### How to test:
-

### Expected outcome:
- [ ]

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
